### PR TITLE
Fixed testAggregateExpr test

### DIFF
--- a/src/test/java/io/mycat/route/DruidMysqlRouteStrategyTest.java
+++ b/src/test/java/io/mycat/route/DruidMysqlRouteStrategyTest.java
@@ -957,7 +957,7 @@ public class DruidMysqlRouteStrategyTest extends TestCase {
         SchemaConfig schema = schemaMap.get("TESTDB");
         String sql = "select id, name, count(name) from employee group by name;";
         RouteResultset rrs = routeStrategy.route(new SystemConfig(), schema, ServerParse.SELECT, sql, null, null, cachePool);
-		Assert.assertTrue(rrs.getMergeCols().containsKey("count2"));
+		Assert.assertTrue(rrs.getMergeCols().containsKey("COUNT2"));
 
         sql = "select id, name, count(name) as c from employee group by name;";
         rrs = routeStrategy.route(new SystemConfig(), schema, ServerParse.SELECT, sql, null, null, cachePool);


### PR DESCRIPTION
 This PR fixes a test called `DruidMysqlRouteStrategyTest.testAggregateExpr` which can be [here](https://github.com/yesh385/Mycat-Server/blob/fix-flaky/src/test/java/io/mycat/route/DruidMysqlRouteStrategyTest.java).

1. What does this test do?

This test is responsible for testing the behavior of the route strategy when processing SQL queries with aggregate functions and different aliasing scenarios. It checks if the result set correctly identifies and names the aggregated columns. 

2. Why does this test fail?

This test fails because we are checking if the HashMap returned by `getMergeCols()` method contains the column name as a key while not checking for case sensitivity. 

3. How I fixed?

This PR fixes this issue by updating the key name into uppercase.

The assertion happens here:
https://github.com/yesh385/Mycat-Server/blob/aacfc6b22d1d89093b1afcb6a72d599167c167b5/src/test/java/io/mycat/route/DruidMysqlRouteStrategyTest.java#L960

You can run the following command to run the test:
```
mvn test -Dtest=io.mycat.route.DruidMysqlRouteStrategyTest#testAggregateExpr
```

Test Environment:
```
java version "1.8.0_202"
Apache Maven 3.6.3
```